### PR TITLE
feat: update to v3.1.1 celestia-app, v0.20.4 celestia-node, celestia-types 0.9.0, celestia-rpc 0.8.0

### DIFF
--- a/ci/Dockerfile.bridge
+++ b/ci/Dockerfile.bridge
@@ -3,7 +3,7 @@
 # A dockerfile for the celestia bridge node in DA layer
 # Based on:
 # https://github.com/celestiaorg/celestia-node/blob/main/Dockerfile
-FROM docker.io/alpine:3.19.1
+FROM docker.io/alpine:3.21.0
 
 ENV CELESTIA_HOME=/root
 

--- a/ci/Dockerfile.bridge
+++ b/ci/Dockerfile.bridge
@@ -10,8 +10,8 @@ ENV CELESTIA_HOME=/root
 RUN apk update && apk add --no-cache bash jq
 
 # Copy in the binary
-COPY --from=ghcr.io/celestiaorg/celestia-node:v0.15.0 /bin/celestia /bin/celestia
-COPY --from=ghcr.io/celestiaorg/celestia-node:v0.15.0 /bin/cel-key /bin/cel-key
+COPY --from=ghcr.io/celestiaorg/celestia-node:v0.20.4 /bin/celestia /bin/celestia
+COPY --from=ghcr.io/celestiaorg/celestia-node:v0.20.4 /bin/cel-key /bin/cel-key
 
 COPY ./run-bridge.sh /opt/entrypoint.sh
 

--- a/ci/Dockerfile.lightnode
+++ b/ci/Dockerfile.lightnode
@@ -3,7 +3,7 @@
 # A dockerfile for the celestia bridge node in DA layer
 # Based on:
 # https://github.com/celestiaorg/celestia-node/blob/main/Dockerfile
-FROM docker.io/alpine:3.19.1
+FROM docker.io/alpine:3.21.0
 
 ENV CELESTIA_HOME=/root
 

--- a/ci/Dockerfile.lightnode
+++ b/ci/Dockerfile.lightnode
@@ -10,8 +10,8 @@ ENV CELESTIA_HOME=/root
 RUN apk update && apk add --no-cache bash jq
 
 # Copy in the binary
-COPY --from=ghcr.io/celestiaorg/celestia-node:v0.15.0 /bin/celestia /bin/celestia
-COPY --from=ghcr.io/celestiaorg/celestia-node:v0.15.0 /bin/cel-key /bin/cel-key
+COPY --from=ghcr.io/celestiaorg/celestia-node:v0.20.4 /bin/celestia /bin/celestia
+COPY --from=ghcr.io/celestiaorg/celestia-node:v0.20.4 /bin/cel-key /bin/cel-key
 
 COPY ./run-lightnode.sh /opt/entrypoint.sh
 

--- a/ci/Dockerfile.validator
+++ b/ci/Dockerfile.validator
@@ -3,7 +3,7 @@
 # A dockerfile for the celestia validator in consensus layer
 # Based on:
 # https://github.com/celestiaorg/celestia-app/blob/main/Dockerfile
-FROM docker.io/alpine:3.19.1
+FROM docker.io/alpine:3.21.0
 
 ENV CELESTIA_HOME=/root
 

--- a/ci/Dockerfile.validator
+++ b/ci/Dockerfile.validator
@@ -10,7 +10,7 @@ ENV CELESTIA_HOME=/root
 RUN apk update && apk add --no-cache bash jq
 
 # Copy in the binary
-COPY --from=ghcr.io/celestiaorg/celestia-app:v3.0.2 /bin/celestia-appd /bin/celestia-appd
+COPY --from=ghcr.io/celestiaorg/celestia-app:v3.1.1 /bin/celestia-appd /bin/celestia-appd
 
 COPY ./run-validator.sh /opt/entrypoint.sh
 

--- a/ci/Dockerfile.validator
+++ b/ci/Dockerfile.validator
@@ -10,7 +10,7 @@ ENV CELESTIA_HOME=/root
 RUN apk update && apk add --no-cache bash jq
 
 # Copy in the binary
-COPY --from=ghcr.io/celestiaorg/celestia-app:v2.0.0 /bin/celestia-appd /bin/celestia-appd
+COPY --from=ghcr.io/celestiaorg/celestia-app:v3.0.2 /bin/celestia-appd /bin/celestia-appd
 
 COPY ./run-validator.sh /opt/entrypoint.sh
 

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - LIGHT_COUNT=1
     volumes:
       - credentials:/credentials
-      - genesis:/genesis
+      - shared:/shared
 
   bridge-0:
     image: bridge
@@ -23,12 +23,16 @@ services:
       # provide an id for the bridge node (default: 0)
       # each node should have a next natural number starting from 0
       - NODE_ID=0
+      # setting SKIP_AUTH to true disables the use of JWT for authentication
       - SKIP_AUTH=true
+      # this must match the service name in the docker-compose.yml file
+      # used for the trusted peers string for the light node
+      - CONTAINER_NAME=bridge-0
     ports:
       - 26658:26658
     volumes:
       - credentials:/credentials
-      - genesis:/genesis
+      - shared:/shared
 
   bridge-1:
     image: bridge
@@ -42,11 +46,14 @@ services:
       - NODE_ID=1
       # setting SKIP_AUTH to true disables the use of JWT for authentication
       - SKIP_AUTH=true
+      # this must match the service name in the docker-compose.yml file
+      # used for the trusted peers string for the light node
+      - CONTAINER_NAME=bridge-1
     ports:
       - 36658:26658
     volumes:
       - credentials:/credentials
-      - genesis:/genesis
+      - shared:/shared
 
   light-0:
     image: light
@@ -55,33 +62,19 @@ services:
       context: .
       dockerfile: Dockerfile.lightnode
     environment:
-      # provide an id for the bridge node (default: 0)
+      # provide an id for the light node (default: 0)
       # each node should have a next natural number starting from 0
       - NODE_ID=0
+      # setting SKIP_AUTH to true disables the use of JWT for authentication
       - SKIP_AUTH=true
+      # depending on the number of bridge nodes, provide the count
+      # is used for the trusted peers string for the light node
+      - BRIDGE_COUNT=2
     ports:
       - 46658:26658
     volumes:
       - credentials:/credentials
-      - genesis:/genesis
-
-  # Uncomment for another bridge node
-  # remember to adjust services.validator.command
-  # bridge-1:
-  #   image: bridge
-  #   platform: "linux/amd64"
-  #   build:
-  #     context: .
-  #     dockerfile: Dockerfile.bridge
-  #   environment:
-  #     # provide an id for the bridge node (default: 0)
-  #     # each node should have a next natural number starting from 0
-  #     - NODE_ID=1
-  #   ports:
-  #     - 36658:26658
-  #   volumes:
-  #     - credentials:/credentials
-  #     - genesis:/genesis
+      - shared:/shared
 
 volumes:
   # local volume where node's credentials can persist
@@ -91,8 +84,8 @@ volumes:
       type: "none"
       o: "bind"
       device: "./credentials"
-  # a temporary fs where the genesis hash is announced
-  genesis:
+  # a temporary fs where the nodes share data
+  shared:
     driver_opts:
       type: tmpfs
       device: tmpfs

--- a/ci/run-bridge.sh
+++ b/ci/run-bridge.sh
@@ -10,7 +10,7 @@ NODE_NAME="bridge-$NODE_ID"
 # a private local network
 P2P_NETWORK="private"
 # a bridge node configuration directory
-CONFIG_DIR="$CELESTIA_HOME/.celestia-bridge-$P2P_NETWORK"
+CONFIG_DIR="$CELESTIA_HOME"
 # directory and the files shared with the validator node
 CREDENTIALS_DIR="/credentials"
 # node credentials

--- a/ci/run-lightnode.sh
+++ b/ci/run-lightnode.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 # Name for this node or `light-0` if not provided
 NODE_ID="${NODE_ID:-0}"
 SKIP_AUTH="${SKIP_AUTH:-false}"
+BRIDGE_COUNT="${BRIDGE_COUNT}"
 NODE_NAME="light-$NODE_ID"
 # a private local network
 P2P_NETWORK="private"
@@ -16,9 +17,10 @@ CREDENTIALS_DIR="/credentials"
 # node credentials
 NODE_KEY_FILE="$CREDENTIALS_DIR/$NODE_NAME.key"
 NODE_JWT_FILE="$CREDENTIALS_DIR/$NODE_NAME.jwt"
-# directory where validator will write the genesis hash
-GENESIS_DIR="/genesis"
-GENESIS_HASH_FILE="$GENESIS_DIR/genesis_hash"
+# directory where validator will write the genesis hash and the bridge node their peers addresses
+SHARED_DIR="/shared"
+GENESIS_HASH_FILE="$SHARED_DIR/genesis_hash"
+TRUSTED_PEERS_FILE="$SHARED_DIR/trusted_peers"
 
 # Wait for the validator to set up and provision us via shared dir
 wait_for_provision() {
@@ -26,8 +28,40 @@ wait_for_provision() {
   while [[ ! ( -e "$GENESIS_HASH_FILE" && -e "$NODE_KEY_FILE" ) ]]; do
     sleep 0.1
   done
-
   echo "Validator is ready"
+
+  echo "Waiting for $BRIDGE_COUNT bridge nodes to start"
+  start_time=$(date +%s)
+  timeout=30
+
+  while true; do
+    if [[ -e "$TRUSTED_PEERS_FILE" ]]; then
+
+      echo "Trusted peers file exists"
+
+      trusted_peers="$(cat "$TRUSTED_PEERS_FILE")"
+      echo "Trusted peers: $trusted_peers"
+      peer_count=$(echo "$trusted_peers" | tr ',' '\n' | wc -l)
+      echo "Peer count: $peer_count"
+      if [[ $peer_count -eq $BRIDGE_COUNT ]]; then
+        echo "$BRIDGE_COUNT bridge nodes are ready"
+        break
+      else
+        echo "Trusted peers file does not contain the expected number of commas. Retrying..."
+      fi
+    else
+      echo "Trusted peers file does not exist yet. Retrying..."
+    fi
+
+    current_time=$(date +%s)
+    elapsed=$((current_time - start_time))
+    if [[ $elapsed -ge $timeout ]]; then
+      echo "Timeout reached. Exiting."
+      exit 1
+    fi
+
+    sleep 1
+  done
 }
 
 # Import the test account key shared by the validator
@@ -43,9 +77,17 @@ add_trusted_genesis() {
 
   # Read the hash of the genesis block
   genesis_hash="$(cat "$GENESIS_HASH_FILE")"
+  trusted_peers="$(cat "$TRUSTED_PEERS_FILE")"
   # and make it trusted in the node's config
   echo "Trusting a genesis: $genesis_hash"
   sed -i'.bak' "s/TrustedHash = .*/TrustedHash = $genesis_hash/" "$CONFIG_DIR/config.toml"
+}
+
+add_trusted_peers() {
+  local trusted_peers="$(cat "$TRUSTED_PEERS_FILE")"
+  local formatted_peers=$(echo "$trusted_peers" | sed 's/\([^,]*\)/"\1"/g')
+  echo "Trusting peers: $formatted_peers"
+  sed -i'.bak' "s|TrustedPeers = .*|TrustedPeers = [$formatted_peers]|" "$CONFIG_DIR/config.toml"
 }
 
 write_jwt_token() {
@@ -62,6 +104,8 @@ main() {
   import_shared_key
   # Trust the private blockchain
   add_trusted_genesis
+  # Trust the bridge nodes
+  add_trusted_peers
   # Update the JWT token
   write_jwt_token
   # give validator some time to set up

--- a/ci/run-lightnode.sh
+++ b/ci/run-lightnode.sh
@@ -10,7 +10,7 @@ NODE_NAME="light-$NODE_ID"
 # a private local network
 P2P_NETWORK="private"
 # a light node configuration directory
-CONFIG_DIR="$CELESTIA_HOME/.celestia-light-$P2P_NETWORK"
+CONFIG_DIR="$CELESTIA_HOME"
 # directory and the files shared with the validator node
 CREDENTIALS_DIR="/credentials"
 # node credentials

--- a/ci/run-validator.sh
+++ b/ci/run-validator.sh
@@ -208,7 +208,7 @@ main() {
   provision_light_nodes &
   # Start the celestia-app
   echo "Configuration finished. Running a validator node..."
-  celestia-appd start --api.enable --grpc.enable
+  celestia-appd start --api.enable --grpc.enable --force-no-bbr
 }
 
 main

--- a/ci/run-validator.sh
+++ b/ci/run-validator.sh
@@ -18,9 +18,9 @@ BRIDGE_COINS="200000000000000utia"
 VALIDATOR_COINS="1000000000000000utia"
 # a directory and the files shared with the bridge nodes
 CREDENTIALS_DIR="/credentials"
-# directory where validator will write the genesis hash
-GENESIS_DIR="/genesis"
-GENESIS_HASH_FILE="$GENESIS_DIR/genesis_hash"
+# directory where validator will write the genesis hash and the bridge node their peers addresses
+SHARED_DIR="/shared"
+GENESIS_HASH_FILE="$SHARED_DIR/genesis_hash"
 
 # Get the address of the node of given name
 node_address() {

--- a/ci/run-validator.sh
+++ b/ci/run-validator.sh
@@ -191,14 +191,12 @@ setup_private_validator() {
   # If you encounter: `sed: -I or -i may not be used with stdin` on MacOS you can mitigate by installing gnu-sed
   # https://gist.github.com/andre3k1/e3a1a7133fded5de5a9ee99c87c6fa0d?permalink_comment_id=3082272#gistcomment-3082272
   sed -i'.bak' 's|"tcp://127.0.0.1:26657"|"tcp://0.0.0.0:26657"|g' "$CONFIG_DIR/config/config.toml"
-  sed -i'.bak' 's|"null"|"kv"|g' "$CONFIG_DIR/config/config.toml"
+  # enable transaction indexing
+  sed -i'.bak' 's|indexer = .*|indexer = "kv"|g' "$CONFIG_DIR/config/config.toml"
 
   # reduce the time of commiting the proposed block
   # bringing this value too low results in errors
   sed -i'.bak' 's|^timeout_commit.*|timeout_commit = "1s"|g' "$CONFIG_DIR/config/config.toml"
-
-  # Set app version to 1
-  sed -i'.bak' 's|"app_version": "2"|"app_version": "1"|g' "$CONFIG_DIR/config/genesis.json"
 }
 
 main() {

--- a/examples/tictactoe/Cargo.lock
+++ b/examples/tictactoe/Cargo.lock
@@ -388,6 +388,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +416,12 @@ name = "bech32"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bincode"
@@ -489,6 +501,18 @@ name = "blockstore"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc99329facbb960effbe7ed707c753a718877c1878eb8ca08704fa391c494020"
+dependencies = [
+ "cid",
+ "dashmap",
+ "multihash",
+ "thiserror",
+]
+
+[[package]]
+name = "blockstore"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a8962daed8fb337472d9c4215006443acba1e40c6c91c9d4a3f440d1fb30436"
 dependencies = [
  "cid",
  "dashmap",
@@ -586,22 +610,39 @@ checksum = "9d7bb5f52d67256ed0545271bb3bbe33f106576884e6acc3cfaedc5bb78c41d3"
 dependencies = [
  "anyhow",
  "celestia-tendermint-proto",
- "prost",
- "prost-build",
- "prost-types",
+ "prost 0.12.6",
+ "prost-build 0.12.6",
+ "prost-types 0.12.6",
  "serde",
 ]
 
 [[package]]
-name = "celestia-rpc"
-version = "0.4.0"
+name = "celestia-proto"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434791f35530f774dba2c8d1a056079b33d309bfef819cbc856b9e8def031376"
+checksum = "c71c3cf9caaf35a7530ea5ac2bab226c9e5c1bad3d661d3527a3951d6f80cbcc"
+dependencies = [
+ "bytes",
+ "prost 0.13.4",
+ "prost-build 0.13.4",
+ "prost-types 0.13.4",
+ "protox",
+ "serde",
+ "subtle-encoding",
+ "tendermint-proto",
+]
+
+[[package]]
+name = "celestia-rpc"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0970073d9e74fc74a417c5157146bbc122462c1dc7b2d5c442fe0b67be40e2cb"
 dependencies = [
  "async-trait",
- "celestia-types",
+ "celestia-types 0.9.0",
  "http 1.1.0",
  "jsonrpsee",
+ "prost 0.13.4",
  "serde",
  "thiserror",
  "tracing",
@@ -622,8 +663,8 @@ dependencies = [
  "futures",
  "num-traits",
  "once_cell",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -646,8 +687,8 @@ dependencies = [
  "flex-error",
  "num-derive",
  "num-traits",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -662,9 +703,9 @@ checksum = "0ca29b1216d1eb09c21f9448fb87f9b50fd7dc2a6266a2f4a846f66c728195e2"
 dependencies = [
  "base64 0.22.1",
  "bech32",
- "blockstore",
+ "blockstore 0.6.1",
  "bytes",
- "celestia-proto",
+ "celestia-proto 0.3.0",
  "celestia-tendermint",
  "celestia-tendermint-proto",
  "cid",
@@ -679,6 +720,37 @@ dependencies = [
  "serde",
  "serde_repr",
  "sha2 0.10.8",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "celestia-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70717cd176178cb3feb43795dd40a6a29ad5e48fae4222d8ba45182b93acbae"
+dependencies = [
+ "base64 0.22.1",
+ "bech32",
+ "bitvec",
+ "blockstore 0.7.1",
+ "bytes",
+ "celestia-proto 0.6.0",
+ "cid",
+ "const_format",
+ "enum_dispatch",
+ "leopard-codec",
+ "libp2p-identity",
+ "multiaddr",
+ "multihash",
+ "nmt-rs",
+ "prost 0.13.4",
+ "ruint",
+ "serde",
+ "serde_repr",
+ "sha2 0.10.8",
+ "tendermint",
+ "tendermint-proto",
  "thiserror",
  "time",
 ]
@@ -858,6 +930,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,6 +1060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -991,6 +1076,20 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
 
 [[package]]
 name = "ed25519"
@@ -1022,6 +1121,25 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1266,6 +1384,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1565,7 +1684,7 @@ dependencies = [
  "bytes",
  "hex",
  "informalsystems-pbjson",
- "prost",
+ "prost 0.12.6",
  "ripemd",
  "serde",
  "sha2 0.10.8",
@@ -1861,6 +1980,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,6 +2092,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "logos"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7251356ef8cb7aec833ddf598c6cb24d17b689d20b993f9d11a3d764e34e6458"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f80069600c0d66734f5ff52cc42f2dabd6b29d205f333d61fd7832e9e9963f"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24fb722b06a9dc12adb0963ed585f19fc61dc5413e6a9be9422ef92c091e731d"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1971,6 +2135,29 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "miette"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317f146e2eb7021892722af37cf1b971f0a70c8406f487e24952667616192c64"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
 
 [[package]]
 name = "mime"
@@ -2450,7 +2637,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "bls12_381",
- "celestia-types",
+ "celestia-types 0.4.0",
  "ed25519-consensus",
  "hex",
  "jmt",
@@ -2535,7 +2722,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.4",
 ]
 
 [[package]]
@@ -2552,8 +2749,28 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+ "regex",
+ "syn 2.0.77",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
+dependencies = [
+ "heck",
+ "itertools 0.12.1",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost 0.13.4",
+ "prost-types 0.13.4",
  "regex",
  "syn 2.0.77",
  "tempfile",
@@ -2573,12 +2790,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20ae544fca2892fd4b7e9ff26cba1090cedf1d4d95c2aded1af15d2f93f270b8"
+dependencies = [
+ "logos",
+ "miette",
+ "once_cell",
+ "prost 0.13.4",
+ "prost-types 0.13.4",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost",
+ "prost 0.12.6",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
+dependencies = [
+ "prost 0.13.4",
+]
+
+[[package]]
+name = "protox"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873f359bdecdfe6e353752f97cb9ee69368df55b16363ed2216da85e03232a58"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost 0.13.4",
+ "prost-reflect",
+ "prost-types 0.13.4",
+ "protox-parse",
+ "thiserror",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a462d115462c080ae000c29a47f0b3985737e5d3a995fcdbcaa5c782068dde"
+dependencies = [
+ "logos",
+ "miette",
+ "prost-types 0.13.4",
+ "thiserror",
 ]
 
 [[package]]
@@ -2723,6 +3002,16 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-registry",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -2957,6 +3246,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "secp256k1"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3163,6 +3466,10 @@ name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core",
+]
 
 [[package]]
 name = "slab"
@@ -3343,6 +3650,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendermint"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d513ce7f9e41c67ab2dd3d554ef65f36fbcc61745af1e1f93eafdeefa1ce37"
+dependencies = [
+ "bytes",
+ "digest 0.10.7",
+ "ed25519",
+ "ed25519-consensus",
+ "flex-error",
+ "futures",
+ "k256",
+ "num-traits",
+ "once_cell",
+ "prost 0.13.4",
+ "ripemd",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "sha2 0.10.8",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "tendermint-proto",
+ "time",
+ "zeroize",
+]
+
+[[package]]
+name = "tendermint-proto"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c81ba1b023ec00763c3bc4f4376c67c0047f185cccf95c416c7a2f16272c4cbb"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "prost 0.13.4",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3386,7 +3738,7 @@ dependencies = [
  "axum",
  "bincode",
  "celestia-rpc",
- "celestia-types",
+ "celestia-types 0.9.0",
  "clap",
  "hex",
  "keystore-rs",
@@ -3653,6 +4005,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"

--- a/examples/tictactoe/Cargo.toml
+++ b/examples/tictactoe/Cargo.toml
@@ -10,8 +10,8 @@ axum = "0.6.0"
 reqwest = { version = "0.12.7", features = ["json"] }
 
 # celestia stuff
-celestia-rpc = "0.4.0"
-celestia-types = "0.4.0"
+celestia-rpc = "0.8.0"
+celestia-types = "0.9.0"
 
 # key management
 prism-common = { git = "https://github.com/deltadevsde/prism", package = "prism-common" }

--- a/examples/tictactoe/src/node.rs
+++ b/examples/tictactoe/src/node.rs
@@ -3,7 +3,7 @@ use async_lock::Mutex;
 use axum::routing::post;
 use axum::Router;
 use celestia_rpc::{BlobClient, HeaderClient};
-use celestia_types::{nmt::Namespace, Blob, TxConfig};
+use celestia_types::{nmt::Namespace, Blob, TxConfig, AppVersion};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Notify;
@@ -100,7 +100,7 @@ impl Node {
         let blob = Blob::new(
             self.cfg.namespace,
             encoded_batch,
-            celestia_types::AppVersion::V3,
+            AppVersion::V3,
         )?;
     
         BlobClient::blob_submit(&self.da_client, &[blob], TxConfig::default()).await?;
@@ -139,8 +139,7 @@ impl Node {
             let blobs = BlobClient::blob_get_all(
                 &self.da_client,
                 height,
-                &[self.cfg.namespace],
-                celestia_types::AppVersion::V3,
+                &[self.cfg.namespace]
             ).await?;
             if let Some(blobs) = blobs {
                 self.process_l1_block(blobs).await;

--- a/examples/tictactoe/src/node.rs
+++ b/examples/tictactoe/src/node.rs
@@ -100,7 +100,7 @@ impl Node {
         let blob = Blob::new(
             self.cfg.namespace,
             encoded_batch,
-            celestia_types::AppVersion::V2,
+            celestia_types::AppVersion::V3,
         )?;
     
         BlobClient::blob_submit(&self.da_client, &[blob], TxConfig::default()).await?;
@@ -140,9 +140,8 @@ impl Node {
                 &self.da_client,
                 height,
                 &[self.cfg.namespace],
-                celestia_types::AppVersion::V2,
-            )
-            .await?;
+                celestia_types::AppVersion::V3,
+            ).await?;
             if let Some(blobs) = blobs {
                 self.process_l1_block(blobs).await;
             }

--- a/src/templates/Cargo.toml
+++ b/src/templates/Cargo.toml
@@ -10,8 +10,8 @@ axum = "0.6.0"
 reqwest = { version = "0.12.9", features = ["json"] }
 
 # celestia stuff
-celestia-rpc = "0.4.0"
-celestia-types = "0.4.0"
+celestia-rpc = "0.8.0"
+celestia-types = "0.9.0"
 
 # key management
 prism-common = { git = "https://github.com/deltadevsde/prism", package = "prism-common" }

--- a/src/templates/node.rs
+++ b/src/templates/node.rs
@@ -3,7 +3,7 @@ use async_lock::Mutex;
 use axum::routing::post;
 use axum::Router;
 use celestia_rpc::{BlobClient, HeaderClient};
-use celestia_types::{nmt::Namespace, Blob, TxConfig};
+use celestia_types::{nmt::Namespace, Blob, TxConfig, AppVersion};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Notify;
@@ -100,7 +100,7 @@ impl Node {
         let blob = Blob::new(
             self.cfg.namespace,
             encoded_batch,
-            celestia_types::AppVersion::V3,
+            AppVersion::V3,
         )?;
     
         BlobClient::blob_submit(&self.da_client, &[blob], TxConfig::default()).await?;
@@ -139,8 +139,7 @@ impl Node {
             let blobs = BlobClient::blob_get_all(
                 &self.da_client,
                 height,
-                &[self.cfg.namespace],
-                celestia_types::AppVersion::V3,
+                &[self.cfg.namespace]
             ).await?;
             if let Some(blobs) = blobs {
                 self.process_l1_block(blobs).await;

--- a/src/templates/node.rs
+++ b/src/templates/node.rs
@@ -100,7 +100,7 @@ impl Node {
         let blob = Blob::new(
             self.cfg.namespace,
             encoded_batch,
-            celestia_types::AppVersion::V2,
+            celestia_types::AppVersion::V3,
         )?;
     
         BlobClient::blob_submit(&self.da_client, &[blob], TxConfig::default()).await?;
@@ -140,9 +140,8 @@ impl Node {
                 &self.da_client,
                 height,
                 &[self.cfg.namespace],
-                celestia_types::AppVersion::V2,
-            )
-            .await?;
+                celestia_types::AppVersion::V3,
+            ).await?;
             if let Some(blobs) = blobs {
                 self.process_l1_block(blobs).await;
             }


### PR DESCRIPTION
Todo:
- [x] get around force-no-bbr not working when running `just celestia-up`. the validator fails to start
- [x] fix light node fail to start
- [x] then test this out with the new celestia-rpc and celestia-types versions with tictactoe
- [x] make sure template code is correct for new version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration for bridge and light nodes with new environment variables.
	- Introduced support for managing trusted peers dynamically.
	- Updated blob creation process to include application versioning.

- **Bug Fixes**
	- Improved handling of peer connections and synchronization for light nodes.

- **Documentation**
	- Clarified comments regarding configuration directories and shared data management.

- **Chores**
	- Updated dependency versions for `celestia-rpc` and `celestia-types` across multiple packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->